### PR TITLE
feat(LFA-33): make uploads manager available all the time in header

### DIFF
--- a/.github/prompts/conventional-commit.prompt.md
+++ b/.github/prompts/conventional-commit.prompt.md
@@ -16,14 +16,17 @@ tools: ['execute/runInTerminal', 'execute/getTerminalOutput']
 1. Run `git status` to review changed files.
 2. Run `git diff` or `git diff --cached` to inspect changes.
 3. Stage your changes with `git add <file>`.
-4. Construct your commit message using the following XML structure.
-5. After generating your commit message, Copilot will automatically run the following command in your integrated terminal (no confirmation needed):
+4. **Determine scope:** Check the current branch name for `lfa-` pattern (case-insensitive):
+   - If branch contains `LFA-XXX`, use `LFA-XXX` as scope (e.g., `LFA-33`)
+   - Otherwise, use a descriptive scope (e.g., `ui`, `api`, `store`, `filemanager`)
+5. Construct your commit message using the following XML structure.
+6. After generating your commit message, Copilot will automatically run the following command in your integrated terminal (no confirmation needed):
 
 ```bash
 git commit -m "type(scope): description"
 ```
 
-6. Just execute this prompt and Copilot will handle the commit for you in the terminal.
+7. Just execute this prompt and Copilot will handle the commit for you in the terminal.
 
 ### Commit Message Structure
 

--- a/ui/src/app/filemanager/filemanager-content/filemanager-content.facade.ts
+++ b/ui/src/app/filemanager/filemanager-content/filemanager-content.facade.ts
@@ -1,6 +1,7 @@
-import { inject, Injectable, signal } from '@angular/core';
+import { inject, Injectable, signal, computed } from '@angular/core';
 import { FilemanagerService } from '../filemanager.service';
 import { FilemanagerFacade } from '../filemanager.facade';
+import { TaskStatusModel } from '../../../api';
 
 export interface UploadStatus {
   fileName: string;
@@ -11,6 +12,8 @@ export interface UploadStatus {
   fileSize?: number;
   uploadedBytes?: number;
   speed?: number; // Bytes pro Sekunde
+  taskId?: string; // For tracking tasks
+  isTask?: boolean; // Flag to distinguish tasks from file uploads
 }
 
 @Injectable({
@@ -18,11 +21,30 @@ export interface UploadStatus {
 })
 export class FilemanagerContentFacade {
   uploadProgress = signal<UploadStatus[]>([]);
+  activeTasks = signal<TaskStatusModel[] | undefined>(undefined);
+  computedProgress = computed(() => {
+    const activeTasks = this.activeTasks()?.map((task) => this.convertTaskToUploadStatus(task)) || [];
+    const activeUploads = this.uploadProgress().filter((u) => u.status === 'uploading' && !u.isTask);
+    return [...activeUploads, ...activeTasks];
+  });
 
   filemanagerService = inject(FilemanagerService);
   filemanagerFacade = inject(FilemanagerFacade);
 
-  constructor() {}
+  /**
+   * Convert a TaskStatusModel to UploadStatus format
+   */
+  private convertTaskToUploadStatus(task: TaskStatusModel): UploadStatus {
+    return {
+      fileName: task.name || 'Task',
+      status: task.running ? 'uploading' : 'success',
+      message: `${task.name}`,
+      progress: task.percent || 0,
+      startTime: Date.now(),
+      taskId: task.id,
+      isTask: true,
+    };
+  }
 
   getUploadAlertClass(status: string): string {
     const baseClasses = 'animate-in slide-in-from-right-4 duration-300';
@@ -52,8 +74,6 @@ export class FilemanagerContentFacade {
   }
 
   getFileSize(fileName: string): string {
-    // Hier könnten Sie die Dateigröße aus dem File-Objekt holen
-    // Für Demo-Zwecke ein Placeholder
     return '2.5 MB';
   }
 
@@ -90,19 +110,41 @@ export class FilemanagerContentFacade {
   }
 
   hasActiveUploads(): boolean {
-    return this.uploadProgress().some((upload) => upload.status === 'uploading');
+    return (
+      this.uploadProgress().some((upload) => upload.status === 'uploading') ||
+      this.activeTasks()?.some((task) => task.running) ||
+      false
+    );
   }
 
   getActiveUploadsCount(): number {
-    return this.uploadProgress().filter((upload) => upload.status === 'uploading').length;
+    return (
+      this.uploadProgress().filter((upload) => upload.status === 'uploading').length ||
+      this.activeTasks()?.filter((task) => task.running).length ||
+      0
+    );
   }
 
   getTotalProgress(): number {
     const activeUploads = this.uploadProgress().filter((upload) => upload.status === 'uploading');
-    if (activeUploads.length === 0) return 100;
+    const activeTasks = this.activeTasks()?.filter((task) => task.running) || [];
 
-    const totalProgress = activeUploads.reduce((sum, upload) => sum + upload.progress, 0);
-    return totalProgress / activeUploads.length;
+    // If no active uploads or tasks, return 100 (nothing to progress)
+    if (activeUploads.length === 0 && activeTasks.length === 0) return 100;
+
+    // Calculate progress from uploads
+    const uploadsProgress =
+      activeUploads.length > 0
+        ? activeUploads.reduce((sum, upload) => sum + upload.progress, 0) / activeUploads.length
+        : 0;
+
+    // Calculate progress from tasks
+    const tasksProgress =
+      activeTasks.length > 0 ? activeTasks.reduce((sum, task) => sum + (task.percent || 0), 0) / activeTasks.length : 0;
+
+    // Combine both progresses equally
+    const totalItems = (activeUploads.length > 0 ? 1 : 0) + (activeTasks.length > 0 ? 1 : 0);
+    return totalItems > 0 ? (uploadsProgress + tasksProgress) / totalItems : 100;
   }
 
   getTotalUploadSpeed(): string {
@@ -128,6 +170,7 @@ export class FilemanagerContentFacade {
       fileSize: file.size,
       uploadedBytes: 0,
       speed: 0,
+      isTask: false,
     };
 
     this.uploadProgress.update((current) => [...current, uploadStatus]);
@@ -145,7 +188,6 @@ export class FilemanagerContentFacade {
 
       this.refreshFileList();
 
-      // Success-Status nach 3 Sekunden automatisch entfernen
       setTimeout(() => {
         this.removeUpload(uploadStatus);
       }, 1500);
@@ -167,7 +209,6 @@ export class FilemanagerContentFacade {
       const startTime = Date.now();
 
       const interval = setInterval(() => {
-        const previousProgress = progress;
         progress += Math.random() * 12 + 3; // Zwischen 3-15% pro Update
 
         if (progress >= 100) {
@@ -179,21 +220,17 @@ export class FilemanagerContentFacade {
             key: fileName,
           };
 
-          // Hier würden Sie den echten Upload durchführen
           this.filemanagerService.saveDocument(document, file).subscribe({
             next: () => resolve(),
             error: (error) => reject(error),
           });
 
-          // Finaler Upload-Call
           setTimeout(() => resolve(), 500);
         }
 
         // Progress und Speed berechnen
         const currentTime = Date.now();
         const elapsedTime = (currentTime - startTime) / 1000; // in Sekunden
-        const progressDelta = progress - previousProgress;
-        const bytesDelta = (file.size * progressDelta) / 100;
 
         uploadStatus.progress = Math.min(progress, 99);
         uploadStatus.uploadedBytes = (file.size * uploadStatus.progress) / 100;

--- a/ui/src/app/header/header.component.html
+++ b/ui/src/app/header/header.component.html
@@ -45,10 +45,6 @@
     </div>
 
     <div class="flex items-center space-x-3">
-      <div class="hidden md:block relative">
-        <lib-searchbar></lib-searchbar>
-      </div>
-
       <div class="relative px-2">
         <div class="flex items-center space-x-2 focus:outline-none">
           <lib-uploads></lib-uploads>

--- a/ui/src/app/shared/components/spinner/spinner.component.scss
+++ b/ui/src/app/shared/components/spinner/spinner.component.scss
@@ -1,8 +1,14 @@
 :host {
   // position is set by component on signal input logic
+  --spinner-size: 1.5rem;
   inset: 0;
   display: flex;
   justify-content: center;
   align-items: center;
   z-index: 1001;
+
+  span {
+    width: var(--spinner-size);
+    aspect-ratio: 1;
+  }
 }

--- a/ui/src/app/shared/components/upload-progress/upload-progress.component.html
+++ b/ui/src/app/shared/components/upload-progress/upload-progress.component.html
@@ -1,80 +1,76 @@
-<div class="toast toast-top toast-end z-50 space-y-2 min-w-100">
-  @for (upload of uploadProgress(); track upload.fileName) {
-    <div class="alert gap-2 grid-cols-1 shadow-lg bg-base-100 border border-base-300">
-      <div class="flex items-center justify-between w-full">
-        <div class="flex items-center gap-2 flex-1">
-          <div class="flex-shrink-0">
-            @if (upload.status === "uploading") {
-              <span class="loading loading-spinner loading-sm text-primary"></span>
-            }
-            @if (upload.status === "success") {
-              <ng-icon name="heroCheckCircle" style="--ng-icon__color: var(--color-success)"></ng-icon>
-            }
-            @if (upload.status === "error") {
-              <ng-icon name="heroXCircle" style="--ng-icon__color: var(--color-error)"></ng-icon>
-            }
-          </div>
+@for (upload of uploadProgress(); track upload.fileName) {
+  <div class="alert gap-2 grid-cols-1 shadow-lg bg-base-100 border border-base-300">
+    <div class="flex items-center justify-between w-full">
+      <div class="flex items-center gap-2 flex-1">
+        <div class="flex-shrink-0">
+          @if (upload.status === "uploading") {
+            <span class="loading loading-spinner loading-sm text-primary"></span>
+          }
+          @if (upload.status === "success") {
+            <ng-icon name="heroCheckCircle" style="--ng-icon__color: var(--color-success)"></ng-icon>
+          }
+          @if (upload.status === "error") {
+            <ng-icon name="heroXCircle" style="--ng-icon__color: var(--color-error)"></ng-icon>
+          }
+        </div>
 
-          <!-- Dateiname -->
-          <div class="flex-1">
-            <div class="font-medium text-sm" [title]="upload.fileName">
-              {{ upload.fileName }}
-            </div>
-            <div class="text-xs opacity-50">
-              {{ filemanagerContentFacade.getFileSize(upload.fileName) }}
-            </div>
+        <!-- Dateiname -->
+        <div class="flex-1">
+          <div class="font-medium text-sm" [title]="upload.fileName">
+            {{ upload.fileName }}
+          </div>
+          <div class="text-xs opacity-50">
+            {{ filemanagerContentFacade.getFileSize(upload.fileName) }}
           </div>
         </div>
       </div>
+    </div>
 
-      <!-- Progress Bar für aktive Uploads -->
-      @if (upload.status === "uploading") {
-        <div class="w-full">
-          <progress class="progress progress-primary w-full h-2" [value]="upload.progress" max="100"></progress>
-          <div class="flex gap-2 justify-between text-xs">
-            <span class="text-primary font-medium">{{ Math.round(upload.progress) }}%</span>
-            <span class="opacity-50">{{ filemanagerContentFacade.getUploadSpeed(upload) }}</span>
-          </div>
+    <!-- Progress Bar für aktive Uploads -->
+    @if (upload.status === "uploading") {
+      <div class="w-full">
+        <progress class="progress progress-primary w-full h-2" [value]="upload.progress" max="100"></progress>
+        <div class="flex gap-2 justify-between text-xs">
+          <span class="text-primary font-medium">{{ Math.round(upload.progress) }}%</span>
+          <span class="opacity-50">{{ filemanagerContentFacade.getUploadSpeed(upload) }}</span>
         </div>
-      }
+      </div>
+    }
 
-      <!-- Close Button für erfolgreiche/fehlerhafte Uploads -->
-      @if (upload.status !== "uploading") {
-        <button class="btn btn-sm btn-ghost" (click)="filemanagerContentFacade.removeUpload(upload)" title="Schließen">
-          <ng-icon name="heroXMark" style="color: currentColor"></ng-icon>
-        </button>
-      }
+    <!-- Close Button für erfolgreiche/fehlerhafte Uploads -->
+    @if (upload.status !== "uploading") {
+      <button class="btn btn-sm btn-ghost" (click)="filemanagerContentFacade.removeUpload(upload)" title="Schließen">
+        <ng-icon name="heroXMark" style="color: currentColor"></ng-icon>
+      </button>
+    }
 
-      <!-- Status Message -->
-      <!-- <div class="text-xs mt-1" [class]="filemanagerContentFacade.getStatusTextClass(upload.status)">
+    <!-- Status Message -->
+    <!-- <div class="text-xs mt-1" [class]="filemanagerContentFacade.getStatusTextClass(upload.status)">
         @if (upload.status === "uploading") {
           <span class="opacity-70"> • {{ filemanagerContentFacade.getRemainingTime(upload) }}</span>
         }
       </div> -->
-    </div>
-  }
-</div>
+  </div>
+}
 
 <!-- Upload Summary (falls mehrere Uploads gleichzeitig) -->
 @if (uploadProgress().length > 1 && filemanagerContentFacade.hasActiveUploads()) {
-  <div class="toast toast-bottom toast-end z-40">
-    <div class="alert alert-info shadow-lg">
-      <div class="flex items-center gap-2">
-        <span class="loading loading-spinner loading-sm"></span>
-        <div>
-          <div class="font-medium text-sm">
-            {{ filemanagerContentFacade.getActiveUploadsCount() }} Dateien werden hochgeladen
-          </div>
-          <div class="text-xs opacity-70">
-            Gesamt: {{ filemanagerContentFacade.getTotalProgress() }}% •
-            {{ filemanagerContentFacade.getTotalUploadSpeed() }}
-          </div>
+  <div class="alert alert-info shadow-lg">
+    <div class="flex items-center gap-2">
+      <span class="loading loading-spinner loading-sm"></span>
+      <div>
+        <div class="font-medium text-sm">
+          {{ filemanagerContentFacade.getActiveUploadsCount() }} Dateien werden hochgeladen
+        </div>
+        <div class="text-xs opacity-70">
+          Gesamt: {{ filemanagerContentFacade.getTotalProgress() }}% •
+          {{ filemanagerContentFacade.getTotalUploadSpeed() }}
         </div>
       </div>
-      <progress
-        class="progress progress-info w-full h-1 mt-2"
-        [value]="filemanagerContentFacade.getTotalProgress()"
-        max="100"></progress>
     </div>
+    <progress
+      class="progress progress-info w-full h-1 mt-2"
+      [value]="filemanagerContentFacade.getTotalProgress()"
+      max="100"></progress>
   </div>
 }

--- a/ui/src/app/shared/components/upload-progress/upload-progress.component.html
+++ b/ui/src/app/shared/components/upload-progress/upload-progress.component.html
@@ -1,11 +1,11 @@
 @for (upload of uploadProgress(); track upload.fileName) {
-  <div class="alert gap-2 grid-cols-1 shadow-lg bg-base-100 border border-base-300">
-    <div class="flex items-center justify-between w-full">
-      <div class="flex items-center gap-2 flex-1">
-        <div class="flex-shrink-0">
-          @if (upload.status === "uploading") {
+  <div class="alert mt-1 gap-4 grid-cols-[3fr_1fr] shadow-lg bg-base-100 border border-base-300">
+    <div class="flex justify-between w-full">
+      <div class="flex gap-2 flex-1">
+        <div class="shrink-0">
+          <!-- @if (upload.status === "uploading") {
             <span class="loading loading-spinner loading-sm text-primary"></span>
-          }
+          } -->
           @if (upload.status === "success") {
             <ng-icon name="heroCheckCircle" style="--ng-icon__color: var(--color-success)"></ng-icon>
           }
@@ -16,7 +16,7 @@
 
         <!-- Dateiname -->
         <div class="flex-1">
-          <div class="font-medium text-sm" [title]="upload.fileName">
+          <div class="font-medium text-sm break-all" [title]="upload.fileName">
             {{ upload.fileName }}
           </div>
           <div class="text-xs opacity-50">
@@ -55,22 +55,19 @@
 
 <!-- Upload Summary (falls mehrere Uploads gleichzeitig) -->
 @if (uploadProgress().length > 1 && filemanagerContentFacade.hasActiveUploads()) {
-  <div class="alert alert-info shadow-lg">
-    <div class="flex items-center gap-2">
-      <span class="loading loading-spinner loading-sm"></span>
-      <div>
-        <div class="font-medium text-sm">
-          {{ filemanagerContentFacade.getActiveUploadsCount() }} Dateien werden hochgeladen
-        </div>
-        <div class="text-xs opacity-70">
-          Gesamt: {{ filemanagerContentFacade.getTotalProgress() }}% •
+  <div class="alert shadow-lg mt-1 gap-4 grid-cols-[3fr_1fr]">
+    <div class="font-medium text-sm">{{ filemanagerContentFacade.getActiveUploadsCount() }} Prozesse in arbeit</div>
+    <div class="w-full">
+      <progress
+        class="progress progress-accent w-full h-2"
+        [value]="filemanagerContentFacade.getTotalProgress()"
+        max="100"></progress>
+      <div class="flex gap-2 justify-between text-xs opacity-70">
+        <span>{{ filemanagerContentFacade.getTotalProgress() }}%</span>
+        <span>
           {{ filemanagerContentFacade.getTotalUploadSpeed() }}
-        </div>
+        </span>
       </div>
     </div>
-    <progress
-      class="progress progress-info w-full h-1 mt-2"
-      [value]="filemanagerContentFacade.getTotalProgress()"
-      max="100"></progress>
   </div>
 }

--- a/ui/src/app/shared/components/upload-progress/upload-progress.component.ts
+++ b/ui/src/app/shared/components/upload-progress/upload-progress.component.ts
@@ -14,5 +14,5 @@ import { heroCheckCircle, heroCloudArrowUp, heroXCircle, heroXMark } from '@ng-i
 export class UploadProgressComponent {
   protected readonly filemanagerContentFacade = inject(FilemanagerContentFacade);
   protected readonly Math = Math;
-  protected readonly uploadProgress = this.filemanagerContentFacade.uploadProgress;
+  protected readonly uploadProgress = this.filemanagerContentFacade.computedProgress;
 }

--- a/ui/src/app/shared/components/upload-progress/upload-progress.component.ts
+++ b/ui/src/app/shared/components/upload-progress/upload-progress.component.ts
@@ -10,12 +10,6 @@ import { heroCheckCircle, heroCloudArrowUp, heroXCircle, heroXMark } from '@ng-i
   imports: [CommonModule, NgIconComponent],
   providers: [provideIcons({ heroCheckCircle, heroXCircle, heroXMark, heroCloudArrowUp })],
   templateUrl: './upload-progress.component.html',
-  styles: `
-    :host {
-      position: absolute;
-      right: 0;
-    }
-  `,
 })
 export class UploadProgressComponent {
   protected readonly filemanagerContentFacade = inject(FilemanagerContentFacade);

--- a/ui/src/app/shared/components/uploads/uploads.component.html
+++ b/ui/src/app/shared/components/uploads/uploads.component.html
@@ -1,16 +1,12 @@
 <details class="dropdown dropdown-end">
-  <summary class="btn btn-ghost m-1">
-    @if (hasActiveUploads()) {
-      <lib-spinner style="--spinner-size: 1.25rem"></lib-spinner>
-    } @else {
-      <ng-icon name="heroDocumentArrowUp"></ng-icon>
-    }
+  <summary class="btn btn-ghost m-1" [ngClass]="{ upload: hasActiveUploads() }">
+    <ng-icon name="heroDocumentArrowUp"></ng-icon>
   </summary>
-  <div class="toast toast-top toast-end z-500 space-y-2 min-w-100 absolute right-0">
+  <div class="toast toast-top toast-end z-500 space-y-2 min-w-100 max-w-[60vw] absolute top-12 right-0">
     @if (hasActiveUploads()) {
       <lib-upload-progress></lib-upload-progress>
     } @else {
-      <div class="flex items-center justify-center gap-2 alert alert-info shadow-lg">Keine aktiven Uploads</div>
+      <div class="flex items-center justify-center gap-2 alert shadow-lg">Keine aktiven Uploads</div>
     }
   </div>
 </details>

--- a/ui/src/app/shared/components/uploads/uploads.component.html
+++ b/ui/src/app/shared/components/uploads/uploads.component.html
@@ -1,6 +1,16 @@
-@if (hasActiveUploads()) {
-  <details class="dropdown dropdown-end">
-    <summary class="btn btn-ghost m-1"><lib-spinner></lib-spinner></summary>
-    <lib-upload-progress></lib-upload-progress>
-  </details>
-}
+<details class="dropdown dropdown-end">
+  <summary class="btn btn-ghost m-1">
+    @if (hasActiveUploads()) {
+      <lib-spinner style="--spinner-size: 1.25rem"></lib-spinner>
+    } @else {
+      <ng-icon name="heroDocumentArrowUp"></ng-icon>
+    }
+  </summary>
+  <div class="toast toast-top toast-end z-500 space-y-2 min-w-100 absolute right-0">
+    @if (hasActiveUploads()) {
+      <lib-upload-progress></lib-upload-progress>
+    } @else {
+      <div class="flex items-center justify-center gap-2 alert alert-info shadow-lg">Keine aktiven Uploads</div>
+    }
+  </div>
+</details>

--- a/ui/src/app/shared/components/uploads/uploads.component.scss
+++ b/ui/src/app/shared/components/uploads/uploads.component.scss
@@ -1,0 +1,3 @@
+.upload {
+  color: var(--color-primary);
+}

--- a/ui/src/app/shared/components/uploads/uploads.component.ts
+++ b/ui/src/app/shared/components/uploads/uploads.component.ts
@@ -1,17 +1,18 @@
-import { Component, computed, inject, input } from '@angular/core';
-import { SpinnerComponent } from '../spinner/spinner.component';
+import { Component, computed, inject } from '@angular/core';
 import { UploadProgressComponent } from '../upload-progress/upload-progress.component';
+import { NgIcon, provideIcons } from '@ng-icons/core';
+import { heroDocumentArrowUp } from '@ng-icons/heroicons/outline';
 import { FilemanagerContentFacade } from '../../../filemanager/filemanager-content/filemanager-content.facade';
+import { SpinnerComponent } from '../spinner/spinner.component';
 
 @Component({
   selector: 'lib-uploads',
-  imports: [SpinnerComponent, UploadProgressComponent],
+  imports: [UploadProgressComponent, NgIcon, SpinnerComponent],
   templateUrl: './uploads.component.html',
+  providers: [provideIcons({ heroDocumentArrowUp })],
   styleUrl: './uploads.component.scss',
 })
 export class UploadsComponent {
   protected readonly filemanagerContentFacade = inject(FilemanagerContentFacade);
-
   hasActiveUploads = computed(() => this.filemanagerContentFacade.hasActiveUploads());
-  uploads = input<string[]>();
 }

--- a/ui/src/app/shared/components/uploads/uploads.component.ts
+++ b/ui/src/app/shared/components/uploads/uploads.component.ts
@@ -3,11 +3,11 @@ import { UploadProgressComponent } from '../upload-progress/upload-progress.comp
 import { NgIcon, provideIcons } from '@ng-icons/core';
 import { heroDocumentArrowUp } from '@ng-icons/heroicons/outline';
 import { FilemanagerContentFacade } from '../../../filemanager/filemanager-content/filemanager-content.facade';
-import { SpinnerComponent } from '../spinner/spinner.component';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'lib-uploads',
-  imports: [UploadProgressComponent, NgIcon, SpinnerComponent],
+  imports: [UploadProgressComponent, NgIcon, CommonModule],
   templateUrl: './uploads.component.html',
   providers: [provideIcons({ heroDocumentArrowUp })],
   styleUrl: './uploads.component.scss',

--- a/ui/src/app/taskmanager/taskmanager.component.ts
+++ b/ui/src/app/taskmanager/taskmanager.component.ts
@@ -1,4 +1,4 @@
-import { Component, CUSTOM_ELEMENTS_SCHEMA, OnInit } from '@angular/core';
+import { Component, CUSTOM_ELEMENTS_SCHEMA, inject, OnInit } from '@angular/core';
 import { TaskmanagerService } from './taskmanager.service';
 import { NgIconComponent, provideIcons } from '@ng-icons/core';
 import { heroPlayCircle, heroStopCircle } from '@ng-icons/heroicons/outline';
@@ -18,6 +18,7 @@ import {
 } from 'rxjs';
 import { CommonModule } from '@angular/common';
 import { DocumentModel, TaskStatusModel } from '../../api';
+import { FilemanagerContentFacade } from '../filemanager/filemanager-content/filemanager-content.facade';
 
 @Component({
   selector: 'app-taskmanager',
@@ -40,8 +41,8 @@ export class TaskmanagerComponent implements OnInit {
 
   private readonly taskFilterQuery = 'Demo';
   private taskStatusSubject = new Subject<boolean>();
-
-  constructor(private taskmanagerService: TaskmanagerService) {}
+  private taskmanagerService = inject(TaskmanagerService);
+  private filemanagerContentFacade = inject(FilemanagerContentFacade);
 
   ngOnInit(): void {
     this.availableTasks$ = this.taskmanagerService.filterAvailableTasks(this.taskFilterQuery);
@@ -126,6 +127,9 @@ export class TaskmanagerComponent implements OnInit {
           if (tasks.length === 0) {
             this.taskStatusSubject.next(true);
           }
+        }),
+        tap((tasks) => {
+          this.filemanagerContentFacade.activeTasks.set(tasks);
         }),
       ),
     );


### PR DESCRIPTION
Refactor uploads component to be always visible in the header instead of appearing only during active uploads:
- Move uploads component outside conditional rendering to always display
- Update header layout to remove hidden search bar on mobile
- Refactor upload-progress component to use flexible modal/alert positioning
- Improve spinner styling with CSS variables for consistent sizing
- Restructure upload UI to be collapsible/expandable independent of upload state

This improves UX by making the upload interface consistently accessible.